### PR TITLE
V0.2.5b

### DIFF
--- a/Assets/TFPSampleScene/TFPSampleScene.unity
+++ b/Assets/TFPSampleScene/TFPSampleScene.unity
@@ -7830,11 +7830,6 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 4744611245860568231, guid: 5ae5ccd8d1c0b59459a598c6f18817a4,
-        type: 3}
-      propertyPath: definedByHeight
-      value: 0
-      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 5ae5ccd8d1c0b59459a598c6f18817a4, type: 3}
 --- !u!1001 &6268786117617452167

--- a/Assets/TFPSampleScene/TFPSampleScene.unity
+++ b/Assets/TFPSampleScene/TFPSampleScene.unity
@@ -7775,6 +7775,11 @@ PrefabInstance:
       propertyPath: m_Name
       value: FootstepsPlayer
       objectReference: {fileID: 0}
+    - target: {fileID: 4744611245860568224, guid: 5ae5ccd8d1c0b59459a598c6f18817a4,
+        type: 3}
+      propertyPath: m_IsActive
+      value: 1
+      objectReference: {fileID: 0}
     - target: {fileID: 4744611245860568230, guid: 5ae5ccd8d1c0b59459a598c6f18817a4,
         type: 3}
       propertyPath: m_LocalPosition.x
@@ -7977,6 +7982,16 @@ PrefabInstance:
         type: 3}
       propertyPath: m_Name
       value: JetpackPlayer
+      objectReference: {fileID: 0}
+    - target: {fileID: 1591015338473822605, guid: 7e16467499665554b8d7ef40344d0c52,
+        type: 3}
+      propertyPath: m_IsActive
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8413570806672767047, guid: 7e16467499665554b8d7ef40344d0c52,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 7e16467499665554b8d7ef40344d0c52, type: 3}

--- a/Assets/TFPSampleScene/TFPSampleScene.unity
+++ b/Assets/TFPSampleScene/TFPSampleScene.unity
@@ -243,7 +243,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 07ff44ff51f260e4b97116fc140cecc0, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  limitFPS: 0
+  limitFPS: 1
   targetFPS: 60
 --- !u!4 &42424299
 Transform:
@@ -7775,11 +7775,6 @@ PrefabInstance:
       propertyPath: m_Name
       value: FootstepsPlayer
       objectReference: {fileID: 0}
-    - target: {fileID: 4744611245860568229, guid: 5ae5ccd8d1c0b59459a598c6f18817a4,
-        type: 3}
-      propertyPath: m_StepOffset
-      value: 0.3
-      objectReference: {fileID: 0}
     - target: {fileID: 4744611245860568230, guid: 5ae5ccd8d1c0b59459a598c6f18817a4,
         type: 3}
       propertyPath: m_LocalPosition.x
@@ -7834,16 +7829,6 @@ PrefabInstance:
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4744611245860568231, guid: 5ae5ccd8d1c0b59459a598c6f18817a4,
-        type: 3}
-      propertyPath: Extensions.Array.size
-      value: 2
-      objectReference: {fileID: 0}
-    - target: {fileID: 4744611245860568231, guid: 5ae5ccd8d1c0b59459a598c6f18817a4,
-        type: 3}
-      propertyPath: Extensions.Array.data[2]
-      value: 
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 5ae5ccd8d1c0b59459a598c6f18817a4, type: 3}

--- a/Assets/TFPSampleScene/TFPSampleScene.unity
+++ b/Assets/TFPSampleScene/TFPSampleScene.unity
@@ -7830,6 +7830,11 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 4744611245860568231, guid: 5ae5ccd8d1c0b59459a598c6f18817a4,
+        type: 3}
+      propertyPath: definedByHeight
+      value: 0
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 5ae5ccd8d1c0b59459a598c6f18817a4, type: 3}
 --- !u!1001 &6268786117617452167

--- a/Assets/TheFirstPerson/Code/Player/FPSController.cs
+++ b/Assets/TheFirstPerson/Code/Player/FPSController.cs
@@ -710,17 +710,18 @@ namespace TheFirstPerson
 
         TFPInfo GetInfo()
         {
-            return new TFPInfo(controller, cam,
-                extensionsEnabled, slopeSlideEnabled, sprintEnabled, momentumEnabled, crouchEnabled, jumpEnabled,
-                verticalLookEnabled, customInputNames, airControl, airSprintEnabled,
-                jumpSpeed, variableHeight, coyoteTime, bunnyhopTolerance, jumpGravityMult, postJumpGravityMult,
-                jumpWhileSliding, slopeJumpKickbackSpeed,
-                gravity, baseGroundForce, maxGroundForce, gravityCap, baseFallVelocity,
-                airResistance, airMoveSpeed, airStrafeMult, airBackwardMult, airSprintMult,
-                moveSpeed, slopeSlideSpeed, acceleration, deceleration, sprintMult, strafeMult, backwardMult,
-                sensitivity, verticalLookLimit,
+            return new TFPInfo(controller, cam, extensionsEnabled, slopeSlideEnabled,
+                sprintEnabled, momentumEnabled, crouchEnabled, jumpEnabled, verticalLookEnabled,
+                customInputNames, airControl, airSprintEnabled, jumpSpeed, variableHeight, coyoteTime,
+                bunnyhopTolerance, jumpGravityMult, postJumpGravityMult, jumpWhileSliding, slopeJumpKickbackSpeed,
+                gravity, baseGroundForce, maxGroundForce, gravityCap, baseFallVelocity, airResistance,
+                airMoveSpeed, airStrafeMult, airBackwardMult, airSprintMult, moveSpeed, slopeSlideSpeed,
+                acceleration, deceleration, sprintMult, strafeMult, backwardMult, sensitivity, verticalLookLimit,
                 crouchToggleStyle, crouchColliderHeight, crouchMult, crouchTransitionSpeed, crouchHeadHitLayerMask,
-                jumpBtn, crouchBtn, runBtn, unlockMouseBtn, xInName, yInName, xMouseName, yMouseName);
+                jumpBtn, crouchBtn, runBtn, unlockMouseBtn, xInName, yInName, xMouseName, yMouseName,
+                mouseLookEnabled, customCameraTransform, normaliseMoveInput, moveInFixedUpdate, definedByHeight,
+                maxJumpHeight, maxJumpTime, minJumpHeight, sprintToggleStyle, sprintByDefault, mouseLockToggleEnabled,
+                startMouseLock);
         }
 
         void SetData(TFPData newData)

--- a/Assets/TheFirstPerson/Code/Player/FPSController.cs
+++ b/Assets/TheFirstPerson/Code/Player/FPSController.cs
@@ -35,9 +35,10 @@ namespace TheFirstPerson
         public bool customCameraTransform = false;
         public bool customInputNames = false;
         [Range(0f, 1f)]
+        [Tooltip("1 is full air control exactly how you control on the ground. 0 is none, you will have no control in the air.")]
         public float airControl = 0.5f;
         public bool airSprintEnabled = true;
-        [Tooltip("This will put a limit of 1 on the magnitude of the horizontal movement input")]
+        [Tooltip("This will put a limit of 1 on the magnitude of the horizontal movement input.")]
         public bool normaliseMoveInput = false;
         public bool moveInFixedUpdate = false;
 
@@ -47,61 +48,88 @@ namespace TheFirstPerson
         [ConditionalHide("jumpEnabled", true)]
         public bool variableHeight = true;
         [ConditionalHide("jumpEnabled", true)]
+        [Tooltip("Time in seconds after you leave an edge that you can still jump.")]
         public float coyoteTime = 0.1f;
         [ConditionalHide("jumpEnabled", true)]
+        [Tooltip("Time in seconds before you hit the ground where you can press jump to jump when you land.")]
         public float bunnyhopTolerance = 0.1f;
         [ConditionalHide(new string[] { "jumpEnabled", "definedByHeight" }, new bool[] { false, true }, true, false)]
+        [Tooltip("Initial in units per second upward velocity of your jump.")]
         public float jumpSpeed = 9;
         [ConditionalHide(new string[] { "jumpEnabled", "definedByHeight" }, new bool[] { false, true }, true, false)]
+        [Tooltip("Gravity that is applied on the upward section of your jump. This multiplies the base gravity variable.")]
         public float jumpGravityMult = 0.6f;
         [ConditionalHide(new string[] { "jumpEnabled", "definedByHeight" }, true, false)]
+        [Tooltip("Maximum height in units that your jump will reach.")]
         public float maxJumpHeight = 4;
         [ConditionalHide(new string[] { "jumpEnabled", "definedByHeight" }, true, false)]
+        [Tooltip("Maximum length of time in seconds your jump will last.")]
         public float maxJumpTime = 1;
         [ConditionalHide(new string[] { "jumpEnabled", "variableHeight", "definedByHeight" }, new bool[]{ false, false, true }, true, false)]
+        [Tooltip("Gravity that is applied while you are traveling upwards after you have let go of the jump button. This multiplies the base gravity variable.")]
         public float postJumpGravityMult = 3;
         [ConditionalHide(new string[] { "jumpEnabled", "variableHeight", "definedByHeight" }, new bool[] { false, false, false }, true, false)]
+        [Tooltip("Maximum height in units that your jump will reach if you let go of the jump button early.")]
         public float minJumpHeight = 1;
-        float minJumpTime = 0.25f;
         [ConditionalHide(new string[] { "jumpEnabled", "slopeSlideEnabled" }, true, false)]
         public bool jumpWhileSliding = false;
         [ConditionalHide(new string[] { "jumpEnabled", "slopeSlideEnabled", "jumpWhileSliding" }, true, false)]
+        [Tooltip("Force in units per second to be applied to the controller away from the surface of a slope too steep to traverse.")]
         public float slopeJumpKickbackSpeed = 10;
 
         [Header("Gravity Settings")]
+        [Tooltip("Gravity variable this is the change in units per second that will be applied to your y velocity.")]
         public float gravity = 15;
+        [Tooltip("Minimum force in units per second pushing you downwards while grounded. This applies on flat ground.")]
         public float baseGroundForce = 3;
+        [Tooltip("Maximum force in units per second pushing you downwards while grounded. This applies on steep slopes.")]
         public float maxGroundForce = 30;
+        [Tooltip("Maximum downwards velocity in units per second.")]
         public float gravityCap = 50;
+        [Tooltip("Base downward velocity applied after walking off an edge in units per second.")]
         public float baseFallVelocity = 5;
 
         [Header("Air Control Settings")]
+        [Tooltip("Speed in units per second that your horizontal velocity returns to 0 in air without any input.")]
         public float airResistance = 4;
+        [Tooltip("Speed in units per second that you move forward in the air.")]
         public float airMoveSpeed = 6;
+        [Tooltip("Speed that you strafe in the air relative to Air Move Speed.")]
         public float airStrafeMult = 0.8f;
+        [Tooltip("Speed that you move backwards in the air relative to Air Move Speed.")]
         public float airBackwardMult = 0.6f;
         [ConditionalHide("airSprintEnabled", true)]
+        [Tooltip("Speed that you sprint in the air relative to Air Move Speed.")]
         public float airSprintMult = 2;
 
         [Header("Speed Settings")]
+        [Tooltip("Base forward speed in units per second.")]
         public float moveSpeed = 5;
         [ConditionalHide("slopeSlideEnabled", true)]
+        [Tooltip("Horizontal speed while sliding in units per second.")]
         public float slopeSlideSpeed = 10;
         [ConditionalHide("momentumEnabled", true)]
+        [Tooltip("Horizontal acceleration in units per second towards target horizontal speed if it is greater than current speed.")]
         public float acceleration = 50;
         [ConditionalHide("momentumEnabled", true)]
+        [Tooltip("Horizontal deceleration in units per second towards target horizontal speed if it is less than current speed.")]
         public float deceleration = 40;
         [ConditionalHide("sprintEnabled", true)]
+        [Tooltip("Speed that you sprint relative to Move Speed.")]
         public float sprintMult = 2;
+        [Tooltip("Speed that you strafe relative to Move Speed.")]
         public float strafeMult = 0.8f;
+        [Tooltip("Speed that you move backwards relative to Move Speed.")]
         public float backwardMult = 0.6f;
 
         [Header("Mouse Look Settings")]
+        [Tooltip("Mouse sensitivity.")]
         public float sensitivity = 10;
         [Tooltip("In editor this may not work correctly but it will in build")]
         public bool mouseLockToggleEnabled = true;
         public bool startMouseLock = true;
         [ConditionalHide("verticalLookEnabled", true)]
+        [Tooltip("Maximum upward or downward angle of the mouselook camera.")]
         public float verticalLookLimit = 80;
         [ConditionalHide("customCameraTransform", true)]
         public Transform cam;
@@ -110,10 +138,13 @@ namespace TheFirstPerson
         [ConditionalHide("crouchEnabled", true)]
         public bool crouchToggleStyle = false;
         [ConditionalHide("crouchEnabled", true)]
+        [Tooltip("Height of the crouch collider.")]
         public float crouchColliderHeight = 0.6f;
         [ConditionalHide("crouchEnabled", true)]
+        [Tooltip("Horizontal speed when crouched relative to Move Speed.")]
         public float crouchMult = 0.5f;
         [ConditionalHide("crouchEnabled", true)]
+        [Tooltip("Speed of transition to and from crouch in units per second.")]
         public float crouchTransitionSpeed = 6;
         [ConditionalHide("crouchEnabled", true)]
         public LayerMask crouchHeadHitLayerMask;
@@ -159,6 +190,7 @@ namespace TheFirstPerson
         float originalMaxJH;
         float originalMinJH;
         float originalJT;
+        float minJumpTime;
 
         //General movement
         Vector3 lastMove;

--- a/Assets/TheFirstPerson/Code/Player/FPSController.cs
+++ b/Assets/TheFirstPerson/Code/Player/FPSController.cs
@@ -115,6 +115,10 @@ namespace TheFirstPerson
         [Tooltip("Horizontal deceleration in units per second towards target horizontal speed if it is less than current speed.")]
         public float deceleration = 40;
         [ConditionalHide("sprintEnabled", true)]
+        public bool sprintToggleStyle = false;
+        [ConditionalHide("sprintEnabled", true)]
+        public bool sprintByDefault = false;
+        [ConditionalHide("sprintEnabled", true)]
         [Tooltip("Speed that you sprint relative to Move Speed.")]
         public float sprintMult = 2;
         [Tooltip("Speed that you strafe relative to Move Speed.")]
@@ -251,6 +255,11 @@ namespace TheFirstPerson
                 yInName = yInNameCustom;
                 xMouseName = xMouseNameCustom;
                 yMouseName = yMouseNameCustom;
+            }
+
+            if(sprintByDefault)
+            {
+                running = true;
             }
 
             if (definedByHeight)
@@ -656,7 +665,21 @@ namespace TheFirstPerson
             {
                 crouching = Input.GetButton(crouchBtn);
             }
-            running = Input.GetButton(runBtn);
+            if (sprintToggleStyle)
+            {
+                if (Input.GetButtonDown(runBtn))
+                {
+                    running = !running;
+                }
+            }
+            else if (sprintByDefault)
+            {
+                running = !Input.GetButton(runBtn);
+            }
+            else
+            {
+                running = Input.GetButton(runBtn);
+            }
             jumpHeld = Input.GetButton(jumpBtn);
             if (Input.GetButtonDown(jumpBtn))
             {

--- a/Assets/TheFirstPerson/Code/Player/TFPExtension.cs
+++ b/Assets/TheFirstPerson/Code/Player/TFPExtension.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections;
+﻿using System;
+using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
 
@@ -45,5 +46,8 @@ namespace TheFirstPerson
 
         //Executes at the end of the move function at this point all movement for the frame has been handled
         public virtual void ExPostMove(ref TFPData data, TFPInfo info) { }
+
+        //executes after input is retrieved, allows you to override input behaviour, useful for things like disabling jumping or running
+        public virtual void ExPostInput(ref TFPData data, TFPInfo info) { }
     }
 }

--- a/Assets/TheFirstPerson/Code/Player/TFPInfo.cs
+++ b/Assets/TheFirstPerson/Code/Player/TFPInfo.cs
@@ -56,20 +56,32 @@ namespace TheFirstPerson
         public string yInName;
         public string xMouseName;
         public string yMouseName;
+        public bool mouseLookEnabled;
+        public bool customCameraTransform;
+        public bool normaliseMoveInput;
+        public bool moveInFixedUpdate;
+        public bool definedByHeight;
+        public float maxJumpHeight;
+        public float maxJumpTime;
+        public float minJumpHeight;
+        public bool sprintToggleStyle;
+        public bool sprintByDefault;
+        public bool mouseLockToggleEnabled;
+        public bool startMouseLock;
 
-        public TFPInfo(CharacterController controller, Transform cam,
-            bool extensionsEnabled, bool slopeSlideEnabled, bool sprintEnabled, bool momentumEnabled, bool crouchEnabled, bool jumpEnabled,
-            bool verticalLookEnabled, bool customInputNames, float airControl, bool airSprintEnabled,
-            float jumpSpeed, bool variableHeight, float coyoteTime, float bunnyhopTolerance, float jumpGravityMult, float postJumpGravityMult,
-            bool jumpWhileSliding, float slopeJumpKickbackSpeed,
-            float gravity, float baseGroundForce, float maxGroundForce, float gravityCap, float baseFallVelocity,
-            float airResistance, float airMoveSpeed, float airStrafeMult, float airBackwardMult, float airSprintMult,
-            float moveSpeed, float slopeSlideSpeed, float acceleration, float deceleration, float sprintMult, float strafeMult, float backwardMult,
-            float sensitivity, float verticalLookLimit,
-            bool crouchToggleStyle, float crouchColliderHeight, float crouchMult, float crouchTransitionSpeed, LayerMask crouchHeadHitLayerMask,
-            string jumpBtn, string crouchBtn, string runBtn, string unlockMouseBtn, string xInName, string yInName, string xMouseName, string yMouseName)
+        public TFPInfo(CharacterController controller, Transform cam, bool extensionsEnabled, bool slopeSlideEnabled,
+            bool sprintEnabled, bool momentumEnabled, bool crouchEnabled, bool jumpEnabled, bool verticalLookEnabled,
+            bool customInputNames, float airControl, bool airSprintEnabled, float jumpSpeed, bool variableHeight, float coyoteTime,
+            float bunnyhopTolerance, float jumpGravityMult, float postJumpGravityMult, bool jumpWhileSliding, float slopeJumpKickbackSpeed,
+            float gravity, float baseGroundForce, float maxGroundForce, float gravityCap, float baseFallVelocity, float airResistance,
+            float airMoveSpeed, float airStrafeMult, float airBackwardMult, float airSprintMult, float moveSpeed, float slopeSlideSpeed,
+            float acceleration, float deceleration, float sprintMult, float strafeMult, float backwardMult, float sensitivity, float verticalLookLimit,
+            bool crouchToggleStyle, float crouchColliderHeight, float crouchMult, float crouchTransitionSpeed, LayerMask crouchHeadHitLayerMask, string
+            jumpBtn, string crouchBtn, string runBtn, string unlockMouseBtn, string xInName, string yInName, string xMouseName, string yMouseName,
+            bool mouseLookEnabled, bool customCameraTransform, bool normaliseMoveInput, bool moveInFixedUpdate, bool definedByHeight,
+            float maxJumpHeight, float maxJumpTime, float minJumpHeight, bool sprintToggleStyle, bool sprintByDefault, bool mouseLockToggleEnabled,
+            bool startMouseLock)
         {
-
             this.controller = controller;
             this.cam = cam;
             this.extensionsEnabled = extensionsEnabled;
@@ -122,6 +134,18 @@ namespace TheFirstPerson
             this.yInName = yInName;
             this.xMouseName = xMouseName;
             this.yMouseName = yMouseName;
+            this.mouseLookEnabled = mouseLookEnabled;
+            this.customCameraTransform = customCameraTransform;
+            this.normaliseMoveInput = normaliseMoveInput;
+            this.moveInFixedUpdate = moveInFixedUpdate;
+            this.definedByHeight = definedByHeight;
+            this.maxJumpHeight = maxJumpHeight;
+            this.maxJumpTime = maxJumpTime;
+            this.minJumpHeight = minJumpHeight;
+            this.sprintToggleStyle = sprintToggleStyle;
+            this.sprintByDefault = sprintByDefault;
+            this.mouseLockToggleEnabled = mouseLockToggleEnabled;
+            this.startMouseLock = startMouseLock;
         }
     }
 }


### PR DESCRIPTION
- Jump settings now have an option to be defined by height and time to the top of the jump. This should make more precise jumping easier to tune.
- New extension function that is called after Input is retrieved this will be useful for modifyinvbg the player input before move is called.
- Normalise Move input now leaves move inputs with magnitudes less than 0 to unmodified.
- Added tooltips for all numeric variables with units mentioned where applicable.
- Added run and walk toggle option and Run By Default option.
- Update TFPinfo to include more recently added variables.