### PR TITLE
Fix spacing in FPSController

### DIFF
--- a/Assets/TheFirstPerson/Code/Player/FPSController.cs
+++ b/Assets/TheFirstPerson/Code/Player/FPSController.cs
@@ -807,8 +807,8 @@ namespace TheFirstPerson
             {
                 running = runHeld;
             }
-            	jumpHeld = standard ? Input.GetButton(jumpBtn) : customInputSystem.JumpHeld();
-if (standard ? Input.GetButtonDown(jumpBtn) : customInputSystem.JumpPressed())
+            jumpHeld = standard ? Input.GetButton(jumpBtn) : customInputSystem.JumpHeld();
+            if (standard ? Input.GetButtonDown(jumpBtn) : customInputSystem.JumpPressed())
             {
                 jumpPressed = coyoteTime;
                 if (moveInFixedUpdate)


### PR DESCRIPTION
This commit realigns the if-statement and the expression above it to
match the whitespace spacing for the rest of the file